### PR TITLE
Tradotti 'printare' ed 'encoded' in quickstart.rst

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -63,7 +63,7 @@ keyword argument ``params``. A titolo di esempio, se volete passare
     >>> payload = {'key1': 'value1', 'key2': 'value2'}
     >>> r = requests.get("http://httpbin.org/get", params=payload)
 
-Potete printare l'URL per verificare che sia stato correttamente encoded::
+Potete stampare l'URL per verificare che sia stato correttamente codificato::
 
     >>> print(r.url)
     http://httpbin.org/get?key2=value2&key1=value1


### PR DESCRIPTION
In quickstart.rst, troviamo:
```
Potete printare l’URL per verificare che sia stato correttamente encoded:
```
Forse sarebbe reso meglio con:
```
Potete stampare l’URL per verificare che sia stato correttamente codificato:
```

Questa richiesta apporta questi cambiamenti. 
